### PR TITLE
Use loops on similar apt_key and rpm_key tasks

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -2,10 +2,10 @@
 
 
   - name: import hp gpgkeys
-    apt_key: state=present key=http://downloads.linux.hp.com/SDR/repo/mcp/GPG-KEY-mcp
-
-  - name: import hp gpgkeys3
-    apt_key: state=present key=http://downloads.linux.hp.com/SDR/repo/mcp/hpPublicKey2048_key1.pub
+    apt_key: state=present key={{ item }}
+    with_items:
+        - http://downloads.linux.hp.com/SDR/repo/mcp/GPG-KEY-mcp
+        - http://downloads.linux.hp.com/SDR/repo/mcp/hpPublicKey2048_key1.pub
 
 #  - name: copy in templates/hpspp.list
 #    template: src=hpspp.list dest=/etc/source.list.d/hpspp.list owner=root group=root mode=0644

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,16 +1,12 @@
 ---
 
   - name: import hp gpgkeys
-    rpm_key: state=present key=http://downloads.linux.hpe.com/SDR/hpPublicKey1024.pub
-
-  - name: import hp gpgkeys2
-    rpm_key: state=present key=http://downloads.linux.hpe.com/SDR/hpPublicKey2048.pub
-
-  - name: import hp gpgkeys3
-    rpm_key: state=present key=http://downloads.linux.hpe.com/SDR/repo/spp/GPG-KEY-SPP
-
-  - name: import hp gpgkeys4
-    rpm_key: state=present key=http://downloads.linux.hpe.com/SDR/repo/stk/GPG-KEY-stk
+    rpm_key: state=present key={{ item }}
+    with_items:
+        - http://downloads.linux.hpe.com/SDR/hpPublicKey1024.pub
+        - http://downloads.linux.hpe.com/SDR/hpPublicKey2048.pub
+        - http://downloads.linux.hpe.com/SDR/repo/spp/GPG-KEY-SPP
+        - http://downloads.linux.hpe.com/SDR/repo/stk/GPG-KEY-stk
 
   - name: template in templates/hpspp.repo
     template: src=hpspp.repo dest=/etc/yum.repos.d/hpspp.repo owner=root group=root mode=0644


### PR DESCRIPTION
Instead of having multiple `apt_key` & `rpm_key` tasks which have almost similar parameters except for the key URL, it's just easier & more economical to use `with_` loops.

https://docs.ansible.com/ansible/playbooks_loops.html
